### PR TITLE
Use https for WFC server

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                 <li><a href="https://asmeditor.skytemple.org/">Effect ASM Editor</a></li>
                 <li><a href="https://sprites.pmdcollab.org/">Sprite Repository</a></li>
                 <li><a href="https://pmdcollab.org/">PMDCollab</a></li>
-                <li><a href="http://wfc.skytemple.org/">WFC Server</a></li>
+                <li><a href="https://wfc.skytemple.org/">WFC Server</a></li>
                 <li><a href="/duskako.html">Duskako</a></li>
                 <li><a href="https://status.pmdcollab.org/">Status</a></li>
             </ul>


### PR DESCRIPTION
The WFC server supports HTTPS for modern clients now.